### PR TITLE
Use latest Hugo and alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # builder image
-FROM golang:1.13
+FROM alpine:latest
 
-ENV HUGO_VERSION 0.64.1
+ENV HUGO_VERSION 0.66.0
 
 LABEL description="gohugo build"
 LABEL version="1.0"
@@ -9,8 +9,10 @@ LABEL maintainer="jholdstock@decred.org"
 
 WORKDIR /tmp
 
+RUN apk update && apk upgrade
+RUN apk add --no-cache bash wget libc6-compat g++
 RUN wget -q https://github.com/gohugoio/hugo/releases/download/v$HUGO_VERSION/hugo_extended_"$HUGO_VERSION"_Linux-64bit.tar.gz
-RUN tar xz -C /usr/local/bin -f  hugo_extended_"$HUGO_VERSION"_Linux-64bit.tar.gz
+RUN tar xz -C /usr/local/bin -f hugo_extended_"$HUGO_VERSION"_Linux-64bit.tar.gz
 
 WORKDIR /root
 


### PR DESCRIPTION
- Use latest Hugo release
- We don't need golang docker image to build, alpine with a couple of deps is enough (>800MB download vs ~5MB download)
